### PR TITLE
Corrected comparison call in OCI_TimestampCompare

### DIFF
--- a/src/timestamp.c
+++ b/src/timestamp.c
@@ -379,7 +379,7 @@ int OCI_API OCI_TimestampCompare
         call_status, tmsp->err, tmsp->con,
 
         OCIDateTimeCompare((dvoid *) tmsp->env, tmsp->err,
-                           tmsp2->handle, tmsp2->handle, &value)
+                           tmsp->handle, tmsp2->handle, &value)
     )
 
 #endif


### PR DESCRIPTION
The third and fourth argument to the OCIDateTimeCompare function should be the first and second timestamp to compare, respectively. Unfortunately, the second timestamp is used for both third and fourth argument.