### PR TITLE
Problems with std::string length=1 and size=1

### DIFF
--- a/include/ocilib_impl.hpp
+++ b/include/ocilib_impl.hpp
@@ -4911,9 +4911,12 @@ inline void Statement::Bind<ostring, unsigned int>(const ostring& name, ostring 
         maxSize = static_cast<unsigned int>(value.size());
     }
 
-    value.reserve(maxSize);
+    unsigned int lengthWithNull = static_cast<unsigned int>(value.length()+1);
+    lengthWithNull  = std::max(maxSize, lengthWithNull);
+    value.reserve(lengthWithNull);
 
     BindObjectAdaptor<otext, ostring> * bnd = new BindObjectAdaptor<otext, ostring>(*this, name, value, maxSize + 1);
+
 
     boolean res = OCI_BindString(*this, name.c_str(), static_cast<otext *>(*bnd), maxSize);
 

--- a/include/ocilib_impl.hpp
+++ b/include/ocilib_impl.hpp
@@ -5729,6 +5729,20 @@ inline ostring Resultset::Get<ostring>(const ostring& name) const
 template<>
 inline Raw Resultset::Get<Raw>(unsigned int index) const
 {
+   if (this->GetColumn(index).GetType() == ocilib::DataTypeValues::TypeLong)
+   {
+      OCI_Long *lg = OCI_GetLong(*this, index);
+      if (lg)
+      {
+	    unsigned char *buffer = (unsigned char *)OCI_LongGetBuffer(lg);
+	    unsigned int size = OCI_LongGetSize(lg);
+	    Raw result = MakeRaw(buffer, size);
+	    OCI_LongFree(lg);
+	    return result;
+      }
+      return Raw();
+   }
+
     unsigned int size = Check(OCI_GetDataLength(*this,index));
 
     ManagedBuffer<unsigned char> buffer(size + 1);


### PR DESCRIPTION
If a i.e. a single character is stored in a std::string (aka ostring /
std::wstring), the call to OCI_BindString will receve size 1, not size 2
(the character and the null terminator character). Therfore the variable
is not correctly bound.