### PR TITLE
Throw dll missing exception when failed to load oci.dll at runtime

### DIFF
--- a/src/exception.c
+++ b/src/exception.c
@@ -340,6 +340,7 @@ void OCI_ExceptionLoadingSharedLib
     {
         err->type    = OCI_ERR_OCILIB;
         err->libcode = OCI_ERR_LOADING_SHARED_LIB;
+        err->raise = 1;
 
         osprintf(err->str, osizeof(err->str) - (size_t) 1,
                   OCILib_ErrorMsg[OCI_ERR_LOADING_SHARED_LIB],


### PR DESCRIPTION
When OCI_IMPORT_RUNTIME defined and oci.dll is not found following message thrown:
OCILIB has not been initialized
but it should throw this message:
Cannot load OCI shared library (oci.dll)