### PR TITLE
Use OCITerminate() call to free memory properly

### DIFF
--- a/src/library.c
+++ b/src/library.c
@@ -190,6 +190,7 @@ static otext * FormatDefaultValues[OCI_FMT_COUNT] =
 /* OCI function pointers */
 
 OCIENVCREATE                 OCIEnvCreate                 = NULL;
+OCITERMINATE                 OCITerminate                 = NULL;
 OCISERVERATTACH              OCIServerAttach              = NULL;
 OCISERVERDETACH              OCIServerDetach              = NULL;
 OCIHANDLEALLOC               OCIHandleAlloc               = NULL;
@@ -820,7 +821,8 @@ boolean OCI_API OCI_Initialize
 
         LIB_SYMBOL(OCILib.lib_handle, "OCIEnvCreate", OCIEnvCreate,
                    OCIENVCREATE);
-
+        LIB_SYMBOL(OCILib.lib_handle, "OCITerminate", OCITerminate,
+                   OCITERMINATE);
         LIB_SYMBOL(OCILib.lib_handle, "OCIServerAttach", OCIServerAttach,
                    OCISERVERATTACH);
         LIB_SYMBOL(OCILib.lib_handle, "OCIServerDetach", OCIServerDetach,
@@ -1591,6 +1593,8 @@ boolean OCI_API OCI_Cleanup
     {
         OCIHandleFree(OCILib.env, OCI_HTYPE_ENV);
     }
+
+    OCITerminate(OCI_DEFAULT);
 
 #ifdef OCI_IMPORT_RUNTIME
 

--- a/src/oci_api.h
+++ b/src/oci_api.h
@@ -79,6 +79,11 @@ typedef sword (*OCIENVCREATE)
     void   **usrmempp
 );
 
+typedef sword(*OCITERMINATE)
+(
+    ub4 mode
+);
+
 typedef sword (*OCIHANDLEALLOC)
 (
     const void  *parenth,

--- a/src/oci_import.h
+++ b/src/oci_import.h
@@ -91,6 +91,7 @@ extern "C" {
 /* symbol list */
 
 extern OCIENVCREATE                 OCIEnvCreate;
+extern OCITERMINATE                 OCITerminate;
 extern OCISERVERATTACH              OCIServerAttach;
 extern OCISERVERDETACH              OCIServerDetach;
 extern OCIHANDLEALLOC               OCIHandleAlloc;


### PR DESCRIPTION
Some memory leak detection tools report memory leaks without this call

You can reproduce issue by running this code:
```
#include <vld.h>
#include <ocilib.hpp>

int main()
{
	ocilib::Environment::Initialize();
	ocilib::Environment::Cleanup();

	return 0;
}
```
with memory leak detection tool enabled ["visual leak detector"](https://vld.codeplex.com/)
You'll see this: http://pastebin.com/bZiF5Z0r

Issue can be reproduced when compiling using visual studio 2010, 2012, 2013(can't reproduce using 2015)