### PR TITLE
Fix for Oracle bug #9838993 workaround

### DIFF
--- a/src/column.c
+++ b/src/column.c
@@ -277,9 +277,9 @@ boolean OCI_ColumnDescribe
         {
             OCIParamStruct *param_struct = (OCIParamStruct*) param;
 
-            if (param_struct && param_struct->column_info && param_struct->column_info->name)
+            if (param_struct && param_struct->column_info && param_struct->column_info->name && (param_struct->column_info->attributes[1] != 0))
             {
-                size_t char_count = OCI_StringLength(param_struct->column_info->name, sizeof(char));
+                size_t char_count = param_struct->column_info->attributes[1];
 
                 OCI_ALLOCATE_DATA(OCI_IPC_STRING, col->name, char_count + 1)
 

--- a/src/ocilib_types.h
+++ b/src/ocilib_types.h
@@ -946,7 +946,8 @@ extern OCI_SQLCmdInfo SQLCmds[];
 
 struct OCIParamStructColumnInfo
 {
-    unsigned char unknown_fields[6 * sizeof(int) + 3 * sizeof(void*)];
+    unsigned char unknown_fields[6 * sizeof(int) + 2 * sizeof(void*)];
+    unsigned char attributes[sizeof(void *)];
     char *name;
 };
 
@@ -954,7 +955,7 @@ typedef struct OCIParamStructColumnInfo OCIParamStructColumnInfo;
 
 struct OCIParamStruct
 {
-    unsigned char unknown_fields[2 * sizeof(void*) + 1 * sizeof(int)];
+    unsigned char unknown_fields[3 * sizeof(void*)];
 
     OCIParamStructColumnInfo *column_info;
 };


### PR DESCRIPTION
Sometimes returned column name contains part of the next columns name.
Changed structs a bit to detect proper length of column name.