### PR TITLE
Handle empty LOBs in OCI_GetString

### DIFF
--- a/src/resultset.c
+++ b/src/resultset.c
@@ -1902,7 +1902,7 @@ const otext * OCI_API OCI_GetString
                 {
                     bufsize = OCI_StringGetFromType(rs->stmt->con, &def->col, data, data_size, def->buf.tmpbuf, FALSE);
 
-                    if (bufsize > 0)
+                    if (bufsize > 0 || (def->col.datatype == OCI_CDT_LOB && data))
                     {
                         OCI_RETVAL = def->buf.tmpbuf;
                     }

--- a/src/string.c
+++ b/src/string.c
@@ -625,6 +625,7 @@ unsigned int OCI_StringGetFromType
     unsigned int len = 0;
 
     otext *ptr = buffer;
+    *ptr = '\0';
 
     if (quote)
     {


### PR DESCRIPTION
reinitialize buffers to empty, and allow return of empty for LOB

closes #112 