### PR TITLE
Added initial CMake support that is able to build and package the libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,46 @@
+cmake_minimum_required(VERSION 2.8 FATAL_ERROR)
+project(ocilib)
+
+set(VERSION_MAJOR 4)
+set(VERSION_MINOR 6)
+set(VERSION_PATCH 0)
+
+set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH};${PROJECT_SOURCE_DIR}/cmake")
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib")
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib")
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin")
+
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+set(CPACK_GENERATOR "RPM")
+set(CPACK_PACKAGE_NAME "ocilib")
+set(CPACK_PACKAGE_CONTACT "")
+set(CPACK_PACKAGE_VERSION "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}")
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "ocilib ${CPACK_PACKAGE_VERSION}")
+set(CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_NAME}-${CPACK_PACKAGE_VERSION}")
+set(CPACK_PACKAGE_HOMEPAGE_URL "https://vrogier.github.io/ocilib/")
+set(CPACK_STRIP_FILES TRUE)
+
+find_package(OracleOCI REQUIRED)
+include(CPack)
+include(CheckIncludeFiles)
+
+check_include_files(dlfcn.h HAVE_DLFCN_H)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config.h.cmakein ${CMAKE_BINARY_DIR}/config.h)
+
+add_definitions(-DHAVE_CONFIG_H)
+
+include_directories(
+	${ORACLE_OCI_INCLUDES}
+	${CMAKE_BINARY_DIR}
+	${CMAKE_SOURCE_DIR}/include)
+
+install(FILES
+	${CMAKE_SOURCE_DIR}/include/ocilib.h
+	${CMAKE_SOURCE_DIR}/include/ocilib.hpp
+	${CMAKE_SOURCE_DIR}/include/ocilib_core.hpp
+	${CMAKE_SOURCE_DIR}/include/ocilib_impl.hpp
+	DESTINATION include)
+
+add_subdirectory(src)
+

--- a/cmake/FindOracleOCI.cmake
+++ b/cmake/FindOracleOCI.cmake
@@ -1,0 +1,45 @@
+set(ORACLE_OCI_FOUND "NO")
+set(ORACLE_OCI_HOME "${ORACLE_HOME}")
+
+if("${ORACLE_OCI_HOME}" STREQUAL "")
+	set(ORACLE_OCI_HOME $ENV{ORACLE_HOME})
+endif()
+
+set(ORACLE_OCI_INCLUDE_LOCATIONS
+	${ORACLE_OCI_HOME}/rdbms/public
+	${ORACLE_OCI_HOME}/include
+	${ORACLE_OCI_HOME}/xdk/include
+	${ORACLE_OCI_HOME}/sdk/include)
+
+set(ORACLE_OCI_LIB_LOCATIONS
+	${ORACLE_OCI_HOME}
+	${ORACLE_OCI_HOME}/lib)
+
+find_path(ORACLE_OCI_INCLUDES
+	oci.h
+	${ORACLE_OCI_INCLUDE_LOCATIONS}
+	NO_DEFAULT_PATH NO_CMAKE_ENVIRONMENT_PATH NO_CMAKE_PATH NO_SYSTEM_ENVIRONMENT_PATH NO_CMAKE_SYSTEM_PATH)
+
+find_library(ORACLE_OCI_LIBRARY_CLNTSH
+	NAMES libclntsh.so.12.2 libclntsh.so.12.1 libclntsh.so.11.1 libclntsh clntsh oci
+	PATHS ${ORACLE_OCI_LIB_LOCATIONS})
+
+find_library(ORACLE_OCI_LIBRARY_CLNTSHCORE
+	NAMES libclntshcore.so.12.2 libclntshcore.so.12.1 libclntshcore clntshcore 
+	PATHS ${ORACLE_OCI_LIB_LOCATIONS})
+
+set(ORACLE_OCI_LIBRARIES
+	${ORACLE_OCI_LIBRARY_CLNTSH}
+	${ORACLE_OCI_LIBRARY_CLNTSHCORE})
+
+if(ORACLE_OCI_INCLUDES AND ORACLE_OCI_LIBRARIES)
+	set(ORACLE_OCI_FOUND "YES")	
+
+	message(STATUS "Found Oracle include directory: ${ORACLE_OCI_INCLUDES}")
+	message(STATUS "Found Oracle libraries: ${ORACLE_OCI_LIBRARIES}")
+elseif(${OracleOCI_FIND_REQUIRED})
+	message(FATAL_ERROR "Could not find Oracle libraries.")
+else()
+	message(STATUS "Could not find Oracle libraries.")
+endif()
+

--- a/config.h.cmakein
+++ b/config.h.cmakein
@@ -1,0 +1,26 @@
+/* Define to 1 if you have the <dlfcn.h> header file. */
+#cmakedefine HAVE_DLFCN_H
+
+/* Name of package */
+#cmakedefine PACKAGE "@CPACK_PACKAGE_NAME@"
+
+/* Define to the address where bug reports for this package should be sent. */
+#cmakedefine PACKAGE_BUGREPORT "@CPACK_PACKAGE_CONTACT@"
+
+/* Define to the full name of this package. */
+#cmakedefine PACKAGE_NAME "@CPACK_PACKAGE_NAME@"
+
+/* Define to the full name and version of this package. */
+#cmakedefine PACKAGE_STRING "@CPACK_PACKAGE_NAME@ @CMAKE_PACKAGE_VERSION@"
+
+/* Define to the one symbol short name of this package. */
+#cmakedefine PACKAGE_TARNAME "@CPACK_PACKAGE_FILE_NAME@"
+
+/* Define to the home page for this package. */
+#cmakedefine PACKAGE_URL "@CPACK_PACKAGE_HOMEPAGE_URL@"
+
+/* Define to the version of this package. */
+#cmakedefine PACKAGE_VERSION "@CMAKE_PACKAGE_VERSION@"
+
+/* Version number of package */
+#cmakedefine VERSION "@CMAKE_PACKAGE_VERSION@"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,68 @@
+set(OCILIB_SOURCES
+	array.c
+	bind.c
+	callback.c
+	connection.c
+	define.c
+	exception.c
+	handle.c
+	iterator.c
+	lob.c
+	mutex.c
+	resultset.c
+	string.c
+	timestamp.c
+	collection.c
+	pool.c
+	element.c
+	file.c
+	hash.c
+	library.c
+	long.c
+	number.c
+	typeinfo.c
+	thread.c
+	transaction.c
+	column.c
+	date.c
+	error.c
+	format.c
+	interval.c
+	list.c
+	memory.c
+	object.c
+	statement.c
+	ref.c
+	threadkey.c
+	dirpath.c
+	event.c
+	subscription.c
+	agent.c
+	dequeue.c
+	enqueue.c
+	msg.c
+	queue.c)
+
+set(OCILIB_INCLUDES
+	oci_api.h
+	oci_defs.h
+	oci_import.h
+	ocilib_checks.h
+	ocilib_defs.h
+	ocilib_internal.h
+	ocilib_types.h
+	oci_loader.h
+	oci_types.h)
+
+add_library(ocilib_shared SHARED ${OCILIB_SOURCES} ${OCILIB_INCLUDES})
+target_link_libraries(ocilib_shared ${ORACLE_OCI_LIBRARIES})
+set_target_properties(ocilib_shared PROPERTIES OUTPUT_NAME "ocilib")
+
+add_library(ocilib_static STATIC ${OCILIB_SOURCES} ${OCILIB_INCLUDES})
+target_link_libraries(ocilib_static ${ORACLE_OCI_LIBRARIES})
+set_target_properties(ocilib_static PROPERTIES OUTPUT_NAME "ocilib")
+
+install(TARGETS
+	ocilib_shared
+	ocilib_static
+	DESTINATION "lib")


### PR DESCRIPTION
This pull request adds an initial support to CMake. It is able to bootstratp, detect the OCI libraries, build and generate static and shared libraries. CPack has been also configured to successfully generate RPM/DEB packages.

It still lacks the support to detect Oracle 18 and the demos/tests are not being built at this point.

