### PR TITLE
Fix for #272

### DIFF
--- a/include/ocilibcpp/detail/support/BindObjectAdaptor.hpp
+++ b/include/ocilibcpp/detail/support/BindObjectAdaptor.hpp
@@ -72,7 +72,7 @@ namespace ocilib
         template<class T>
         BindObjectAdaptor<T>::~BindObjectAdaptor() noexcept
         {
-            delete core::OnDeallocate(_data);
+            delete[] core::OnDeallocate(_data);
         }
 
         template<class T>


### PR DESCRIPTION
#272 
The allocation happens just above `_data(core::OnAllocate(new NativeType[size + 1], size + 1)),`