### PR TITLE
Add missing OCI_VER_MAKE

### DIFF
--- a/src/connection.c
+++ b/src/connection.c
@@ -1664,7 +1664,7 @@ const otext * OcilibConnectionGetServerVersion
                                                   (int*)&ver_min,
                                                   (int*)&ver_rev))
                     {
-                        con->ver_num = ver_maj * 100 + ver_min * 10 + ver_rev;
+                        con->ver_num = OCI_VER_MAKE(ver_maj, ver_min, ver_rev);
                     }
 
                     break;


### PR DESCRIPTION
The old style small version number leads to wrong feature detection and who know what else