### PR TITLE
feat: correct converted rows when OCI_DPR_FULL occurs

### DIFF
--- a/demo/dirpath_complete.c
+++ b/demo/dirpath_complete.c
@@ -1,4 +1,5 @@
 #include "ocilib.h"
+#include "types.h"
 
 /* Direct path complete test suite demonstrating the following workflows :
 
@@ -259,6 +260,9 @@ void do_load(OCI_Connection *con, boolean gen_conv_error, boolean gen_load_error
 
                 while (nb_conv < SIZE_ARRAY)
                 {
+                    /* reset dp->nb_cur to the number of remaining rows not converted */
+                    dp->nb_cur = SIZE_ARRAY - nb_conv;
+                    
                     for (j = 1; j <= nb_rows - nb_conv; j++)
                     {
                         sprintf(val1, "%04d", (j + nb_conv) + (i*SIZE_ARRAY));

--- a/src/dirpath.c
+++ b/src/dirpath.c
@@ -982,6 +982,7 @@ boolean OcilibDirPathReset
     dp->idx_err_row  = 0;
     dp->idx_err_col  = 0;
     dp->load_offset  = 0;
+    dp->nb_cur = dp->nb_rows;
 
     /* reset array */
 


### PR DESCRIPTION
Each time the function `OCI_DirPathConvert` is called,  `dp->nb_cur` rows would be converted, sees `dirpath.c:1060` --> `dirpath.c:39` in function `OcilibDirPathSetArray`:
```C
// dirpath.c:39-102
static boolean OcilibDirPathSetArray
(
    OCI_DirPath *dp,
    ub4          row_from
)
{
    ...
    for (row = row_from; row < dp->nb_cur; row++)
    {
           .... 
        /* increment number of item set */
        dp->nb_entries++;
    }
.... 
```
 the final numer connverted in a round shall be doubled:
```C
// dirpath_complete.c: 261-279
                while (nb_conv < SIZE_ARRAY)
                {
                    ...
                    /* convert again */

                    state = OCI_DirPathConvert(dp);

                    nb_conv = OCI_DirPathGetAffectedRows(dp);
```

So resetting dp->nb_cur is needed to ensure that there would be exactly nb_rows being converted in a round:
```C 
// dirpath_complete.c: 263-264
  /* reset dp->nb_cur to the number of remaining rows not converted */
  dp->nb_cur = SIZE_ARRAY - nb_conv;
```
Consequently, it's also needed that resetting dp->nb_cur to dp->nb_rows every time `OcilibDirPathReset` is called:
```C 
// dirpath_complete.c: 985
dp->nb_cur = dp->nb_rows;
```

I have verified this fixing in production, wish you accept it. ^_^